### PR TITLE
Feat - Pick up the actor that was placed on display actor.

### DIFF
--- a/VRGuild/Source/VRGuild/Private/Hall/Actors/CADisplayer.cpp
+++ b/VRGuild/Source/VRGuild/Private/Hall/Actors/CADisplayer.cpp
@@ -150,10 +150,19 @@ void ACADisplayer::OnRep_Owner()
 			else UE_LOG(LogTemp, Warning, TEXT("ACADisplayer, OnRep_Owner, no carried actor in UCACCarryComponent"));
 		}
 	}
+	else
+	{
+		if (WidgetComponent)
+		{
+			WidgetComponent->SetWidgetClass(nullptr);
+		}
+	}
 }
 
 void ACADisplayer::OnRep_ActorDisplayed()
 {
+	if (!WidgetComponent) return;
+
 	if (ActorDisplayed)
 	{
 		UE_LOG(LogTemp, Warning, TEXT("Success in displaying Actor Displayed"));
@@ -198,7 +207,11 @@ void ACADisplayer::ServerPickupCommission_Implementation(ACharacter* player)
 	{
 		if (auto carryComp = player->GetComponentByClass<UCACCarry>())
 		{	
-			//carryComp->StartCarry(ActorDisplayed);
+			carryComp->StartCarry(ActorDisplayed);
+			SetOwner(nullptr);
+			ActorDisplayed->SetActorHiddenInGame(true);
+			ActorDisplayed->SetLifeSpan(10.f);
+			ActorDisplayed = nullptr;
 		}
 	}
 	else


### PR DESCRIPTION
내용
---------
May need to optimize how i handle removing widget in WidgetComponent. 

Both the Owner and ActorDisplayed variables remove the widget when replicated.

```
void ACADisplayer::ServerPickupCommission_Implementation(ACharacter* player)
{
	if (!player || !Owner) return;
	
	if (Owner == player)
	{
		if (auto carryComp = player->GetComponentByClass<UCACCarry>())
		{	
			carryComp->StartCarry(ActorDisplayed);
			SetOwner(nullptr);
			ActorDisplayed->SetActorHiddenInGame(true);
			ActorDisplayed->SetLifeSpan(10.f);
			ActorDisplayed = nullptr;
		}
	}
	else
	{

	}
}
```
체크 리스트
---------
<!-- 완료한 부분에 x를 넣어 주세요 `x` -->
<!-- 무엇인지 모르겠으면 질문하세요! 우리는 언제나 질문에 성심성의것 답변할 준비가 되어있습니다. -->

- [x] PR 하기전 사전 이슈를 확인 완료하였습니다.
- [x] 충돌사항을 정검하였습니다.
- [x] 코드 스타일 가이드에 맞는지 확인하였습니다.
- [x] 기술적인 버그 발생 사항을 충분히 고려하였습니다.
- [x] 깃 로그를 정리 하였습니다.
- [x] 테스트 코드가 정상적으로 돌아가며 신뢰할 수 있습니다.

💯 완료
---------
🎉 수고 하셨습니다!! 🚀

🌈 코드에 기여함을 언제나 감사합니다.

PR 작업한 결과에 대하여 모든 코드는 공유, 배포, 수정, 복사 및 재배포 될 수 있음을 확인합니다.